### PR TITLE
Port from PyQt4 to PyQt5

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -121,7 +121,7 @@ class LauncherWindow(QMainWindow):
         self.mainLayout = QVBoxLayout(mainWidget)
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.setCentralWidget(mainWidget)
-        # Main window consist of filter/serach entry and a main button which
+        # Main window consist of filter/search entry and a main button which
         # pops up the root menu. Create a layout and add the items.
 
         self.launcherMenu = LauncherSubMenu(self.menuModel, None, mainWidget)
@@ -272,14 +272,14 @@ class LauncherMenu(QMenu):
     def setFilterCondition(self, condition, value):
         """ Set one condition to given value."""
 
-        self.filterConditions[condition.value] = value
+        self.filterConditions[condition] = value
         self.filterMenu(self.filterTerm)
 
     def getLauncherWindow(self):
         """ Search and return application main window object"""
 
         candidate = self
-        while type(candidate) is not LauncherWindow:
+        while type(candidate) != LauncherWindow:
             candidate = candidate.parent()
 
         return candidate
@@ -296,9 +296,9 @@ class LauncherMenu(QMenu):
         # Read filters
 
         sensitivityFilter = self.filterConditions[
-            SearchOptions.sensitivity.value]
-        textFilter = self.filterConditions[SearchOptions.text.value]
-        cmdFilter = self.filterConditions[SearchOptions.cmd.value]
+            SearchOptions.sensitivity]
+        textFilter = self.filterConditions[SearchOptions.text]
+        cmdFilter = self.filterConditions[SearchOptions.cmd]
         # Skip first item since it is either search entry or detach button.
 
         for action in self.actions()[1:len(self.actions())]:
@@ -555,7 +555,7 @@ class LauncherSearchMenuView(LauncherMenu):
         self.setEnabled(True)
         self.show()
         self.searchWidget.setFocus()
-        # self.move(self.pos().x(), self.pos().y()) TODO
+        #self.move(self.pos().x(), self.pos().y()) TODO
 
     def changeEvent(self, changeEvent):
         """Catch when menu window is selected and focus to search."""
@@ -641,7 +641,8 @@ class LauncherFilterLineEdit(QLineEdit):
 
     def resizeEvent(self, event):
         position = QtCore.QPoint(self.pos().x()+self.width() -
-                                 self.clearButton.width(), 0)
+                                 self.clearButton.width(), 
+                                 self.pos().y()+0.5*self.height()-self.clearButton.height())
         self.clearButton.move(position)
 
     def keyPressEvent(self, event):
@@ -681,7 +682,7 @@ class LauncherFilterWidget(QWidget):
     def __init__(self, menu, parent=None):
         QWidget.__init__(self, parent)
         mainLayout = QHBoxLayout(self)
-        # mainLayout.setMargin(0) # not any more in qt5
+        mainLayout.setContentsMargins(0,0,0,0)
         mainLayout.setSpacing(0)
 
         self.setLayout(mainLayout)
@@ -733,7 +734,7 @@ class LauncherSearchWidget(QWidget):
     def __init__(self, menu, parent=None):
         QWidget.__init__(self, parent)
         mainLayout = QVBoxLayout(self)
-        # mainLayout.setMargin(0)
+        mainLayout.setContentsMargins(0,0,0,0)
         self.setLayout(mainLayout)
         # Prepare components and add them to layout:
         #    - search field
@@ -1156,10 +1157,10 @@ class LauncherFileChoiceAction(QAction):
 
     def changeView(self):
         """Find LauncherWindow and set new view."""
-
+     
         candidate = self
-        while candidate.__class__.__name__ is not "LauncherWindow":
-            candidate = candidate.parent()
+        while candidate.__class__.__name__ !=  "LauncherWindow":
+           candidate = candidate.parent()
         candidate.setNewView(self.itemModel.root_menu_file, self.itemModel.text)
 
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -612,25 +612,10 @@ class LauncherFilterLineEdit(QLineEdit):
         self.textChanged.connect(lambda: self.menu.filterMenu(self.text()))
         self.myAction = None
         self.setPlaceholderText("Enter filter term.")
+        self.setClearButtonEnabled(True)
         # Create button to clear text and add it to the right edge of the
         # input.
-
-        self.clearButton = QToolButton(self)
-        self.clearButton.setFixedSize(27, 27)
-        self.setTextMargins(0, 0, 30, 0)
-        currDir = os.path.dirname(os.path.realpath(__file__))
-        icon = QIcon(os.path.join(currDir, "resources/images/delete-2x.png"))
-        self.clearButton.setIcon(icon)
-
-        self.clearButton.setStyleSheet("background-color: transparent; \
-                                        border: none")
-        self.clearButton.setFocusPolicy(Qt.NoFocus)
-
         self.setMinimumWidth(200)
-        position = QtCore.QPoint(self.pos().x()+self.width(), 0)
-        self.clearButton.move(position)
-        self.clearButton.setCursor(Qt.ArrowCursor)
-        self.clearButton.clicked.connect(lambda: self.clear())
         # Set search policy (default False). If True it opens search when
         # Enter is pressed
 
@@ -638,12 +623,6 @@ class LauncherFilterLineEdit(QLineEdit):
 
     def setMyAction(self, action):
         self.myAction = action
-
-    def resizeEvent(self, event):
-        position = QtCore.QPoint(self.pos().x()+self.width() -
-                                 self.clearButton.width(), 
-                                 self.pos().y()+0.5*self.height()-self.clearButton.height())
-        self.clearButton.move(position)
 
     def keyPressEvent(self, event):
         """Catch key pressed event.
@@ -682,8 +661,6 @@ class LauncherFilterWidget(QWidget):
     def __init__(self, menu, parent=None):
         QWidget.__init__(self, parent)
         mainLayout = QHBoxLayout(self)
-        mainLayout.setContentsMargins(0,0,0,0)
-        mainLayout.setSpacing(0)
 
         self.setLayout(mainLayout)
 
@@ -753,6 +730,7 @@ class LauncherSearchWidget(QWidget):
         mainLayout.addWidget(caseSensitive)
         options = QWidget(self)
         optionsLayout = QHBoxLayout(options)
+        optionsLayout.setContentsMargins(0, 0, 0, 0)
         searchText = QCheckBox("Title search", options)
         searchText.setChecked(True)
         searchText.stateChanged.connect(
@@ -1157,7 +1135,7 @@ class LauncherFileChoiceAction(QAction):
 
     def changeView(self):
         """Find LauncherWindow and set new view."""
-     
+
         candidate = self
         while candidate.__class__.__name__ !=  "LauncherWindow":
            candidate = candidate.parent()

--- a/src/launcher_model.py
+++ b/src/launcher_model.py
@@ -11,14 +11,9 @@ from __future__ import division
 from __future__ import absolute_import
 
 import sys
-# if sys.hexversion >= 0x03000000:
-from urllib.request import urlopen
-from urllib.parse import urljoin
-from urllib.error import URLError
-# else:
-#     from urllib2 import urlopen
-#     from urlparse import urljoin
-#     from urllib2 import URLError
+from urllib2 import urlopen
+from urlparse import urljoin
+from urllib2 import URLError
 # ------end of python 2/3 compatibility imports-----
 
 import os


### PR DESCRIPTION
Qt4 -> Qt5

1. Some of the work was already done beforehand, i.e. PyQt4 packages were already replaced with PyQt5 ones
2. went through the list of all the changes between Qt4 and Qt5 and checked if they affect pylauncher

QDesktopServices
- no obsolete members used
QIcon
- no obsolete members used
QCursor
- no obsolete members
QKeySequence
- no obsolete members used
QMainWindow
- no obsolete members
QMenu
- no obsolete members
QWidgetAction
- no obsolete members
QLineEdit
- no obsolete members used
QWidget
- no obsolete members used
QHBoxLayout
QVBoxLayout
- QLayout has an obsolete member setMargin
- replaced with setContentsMargins()
QToolButton
- no obsolete members
QCheckBox
- no obsolete members
QAction
- no obsolete members
QLabel
- no obsolete members
QPushButton
- no obsolete members
QApplication
- no obsolete members used
I also checked other functionality through the code

3. double checked and ran the code in conda environments with both PyQt4 and PyQt5

4. fixed two additional bugs:

Traceback (most recent call last):
  File "/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher/lib/python2.7/site-packages/pylauncher/launcher.py", line 1150, in openSearch
    self.parent().parent().launcherMenu)
  File "/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher/lib/python2.7/site-packages/pylauncher/launcher.py", line 517, in __init__
    self.searchWidget = LauncherSearchWidget(self, self.getMainMenu())
  File "/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher/lib/python2.7/site-packages/pylauncher/launcher.py", line 761, in __init__
    caseSensitive.isChecked())
  File "/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher/lib/python2.7/site-packages/pylauncher/launcher.py", line 287, in setFilterCondition
    self.filterConditions[condition.value] = value
AttributeError: 'int' object has no attribute 'value'

(psi-pylauncher-pip)[pc11508 pylauncher]$ pylauncher -m examples/mapping/mapping.json -s examples/themes/green.qss examples/menus2/menu_5.json 
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-novak_i'
WARNING:root:Parser: file:////afs/psi.ch/user/n/novak_i/novak_i/pylauncher/examples/menus2/menu_5.json: File "menu_10.json" not found. Skipped
Traceback (most recent call last):
  File "/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher-pip/lib/python2.7/site-packages/pylauncher/launcher.py", line 1162, in changeView
    candidate = candidate.parent()
AttributeError: 'NoneType' object has no attribute 'parent'
Aborted

5. Tested with examples in pylauncher repository as well as some additional repositories from https://git.psi.ch/launcher_config

6. System info:
ca-certificates           2019.11.27                    0    anaconda
cairo                     1.14.12              h8948797_3    anaconda
certifi                   2016.2.28                py27_0    defaults
dbus                      1.13.12              h746ee38_0    anaconda
enum                      0.4.7                     <pip>
expat                     2.2.6                he6710b0_0    anaconda
fontconfig                2.13.0               h23c43c1_0    anaconda
freetype                  2.9.1                h8a8886c_0    anaconda
fribidi                   1.0.5                h7b6447c_0    anaconda
future                    0.16.0                   py27_1    defaults
glib                      2.56.2               hd408876_0    anaconda
graphite2                 1.3.13               h23475e2_0    anaconda
gst-plugins-base          1.14.0               hbbd80ab_1    anaconda
gstreamer                 1.14.0               hb453b48_1    anaconda
harfbuzz                  1.7.6                hec2c2bc_3    anaconda
icu                       58.2                 h211956c_0    anaconda
jpeg                      9b                   habf39ab_1    anaconda
libedit                   3.1.20181209         hc058e9b_0    anaconda
libffi                    3.2.1                         1    defaults
libgcc-ng                 9.1.0                hdf63c60_0    anaconda
libiconv                  1.14                          0    defaults
libpng                    1.6.35               hbc83047_0    anaconda
libstdcxx-ng              9.1.0                hdf63c60_0    anaconda
libuuid                   1.0.3                h1bed415_2    anaconda
libxcb                    1.13                 h1bed415_1    anaconda
libxml2                   2.9.8                hf84eae3_0    anaconda
ncurses                   6.1                  he6710b0_1    anaconda
openssl                   1.1.1d               h7b6447c_0    anaconda
pango                     1.42.0               h8589676_1    anaconda
pcre                      8.42                 h439df22_0    anaconda
pip                       9.0.1                    py27_1    defaults
pixman                    0.34.0                        0    defaults
pylauncher (/afs/psi.ch/user/n/novak_i/.conda/envs/psi-pylauncher-pip/lib/python2.7/site-packages) 1.4.0                     <pip>
pylauncher                1.4.0                    py27_0    file:///afs/psi.ch/user/n/novak_i/conda-bld/linux-64/pylauncher-1.4.0-py27_0.tar.bz2
pyparsing                 2.2.0                    py27_0    defaults
pyqt                      5.9.2            py27h05f1152_2    anaconda
python                    2.7.17               h9bab390_0    anaconda
python-qt                 0.50                      <pip>
qt                        5.9.7                h5867ecd_1    anaconda
readline                  7.0                  h7b6447c_5    anaconda
setuptools                36.4.0                   py27_1    defaults
sip                       4.19.8           py27hf484d3e_0    anaconda
sqlite                    3.30.0               h7b6447c_0    anaconda
tk                        8.6.8                hbc83047_0    anaconda
wheel                     0.29.0                   py27_0    defaults
xz                        5.2.4                h14c3975_4    anaconda
zlib                      1.2.11                        0    defaults

7. It seems that some of the margins and other settings should still be fixed, but since they look the same in the currently installed version of launcher and not the result of port to qt5, I did not fix them. 
